### PR TITLE
Serve up redirects on /a/list

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,13 @@ app.get('/', function(req,res){
   });
 });
 
+app.get('/a/list', function(req,res){
+  res.render('list', {
+    error: false,
+    redirects: redirects
+  });
+});
+
 app.get('/:wanted', function(req,res){
   if (typeof(redirects[req.params.wanted]) === 'undefined') {
     // I don't know that link

--- a/views/list.html
+++ b/views/list.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="//style.codeforamerica.org/2/style/css/main.css">
+  <link rel="stylesheet" href="//style.codeforamerica.org/2/style/css/cfa-light.css">
+  <link rel="stylesheet" href="//style.codeforamerica.org/2/style/css/layout.css" media="all and (min-width: 40em)">
+  <title>Redirect - Code for America</title>
+  <style>
+    h1 {
+      text-transform: none;
+      letter-spacing: -0.05em;
+    }
+    h3 {
+      text-transform: none;
+      font-weight: 700;
+    }
+    .redirect-list {
+      font-size: 0.8em;
+    }
+    .redirect-list li + li {
+      margin-top: 1em;
+    }
+  </style>
+</head>
+<body>
+  <div class="layout-semibreve">
+    <% if (error) { %>
+      <div class="alert-failure">
+        <p><strong>Error: Link not found.</strong></p>
+        <p>Sorry, I couldn't find the link <strong><%= request_url %></strong>. Please make sure you entered the URL correctly. If you're still having issues, please reach out to us at <a href="mailto:info@codeforamerica.org">info@codeforamerica.org</a>.</p>
+      </div>
+    <% } %>
+    <h1>Redirect</h1>
+    <p>This is a simple tool provided by <a href="https://www.codeforamerica.org">Code for America</a> to serve shortlinks. All links are held in the <a href="https://github.com/codeforamerica/redirect">Github repo</a>.</p>
+    <a href="https://github.com/codeforamerica/redirect" class="button">Create a shortlink</a>
+  </div>
+  <div class="layout-semibreve">
+    <h3>List of available redirects</h3>
+    <p>These redirects are currently set up:</p>
+    <ul class="list-no-bullets redirect-list">
+    <% for (var redirect in redirects) { %>
+      <li>
+        <a href="http://c4a.me/<%- redirect %>">http://c4a.me/<%- redirect %></a> points to <a href="<%- redirects[redirect] %>"><%- redirects[redirect] %></a>
+      </li>
+    <% } %>
+    </ul>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Users can visit /a/list and see all the available redirects. /a/ is now a protected path saved for the app.
