### PR TITLE
Add a well-known status endpoint for engine-light testing

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,15 @@ var startApp = function(cb) {
     }
   });
 
+  app.get('/.well-known/status', function(req,res){
+    res.json({
+      status: "ok",
+      updated: new Date().getTime(),
+      dependencies: [],
+      resources: {}
+    });
+  });
+
   var server = app.listen(process.env.PORT || 3000, function(){
     var host = server.address().address;
     var port = server.address().port;

--- a/tests/test.js
+++ b/tests/test.js
@@ -31,6 +31,20 @@ app(function(err,host,port,server){
     },
     function(cb){
 
+      request(server)
+        .get('/.well-known/status')
+        .expect(200)
+        .end(function(err,res){
+          assert.doesNotThrow(
+            function(){ if (err) throw err; },
+            "The /.well-know/status"
+          );
+          cb();
+        });
+
+    },
+    function(cb){
+
       async.forEachOfSeries(redirects, function(val,key,cb){
         request(server)
           .get('/'+key)


### PR DESCRIPTION
We're also testing that this endpoint returns 200 (OK), but not testing for the actual content it returns for now (we can expect if it's 200 it's got the content).
