### PR TITLE
Output well-known time in seconds instead of milliseconds, round with Math.floor()

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,7 +36,7 @@ var startApp = function(cb) {
   app.get('/.well-known/status', function(req,res){
     res.json({
       status: "ok",
-      updated: new Date().getTime(),
+      updated: Math.floor(new Date() / 1000),
       dependencies: [],
       resources: {}
     });


### PR DESCRIPTION
cc @migurski 
