### PR TITLE
Change the link URL for creating a new redirect

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -61,7 +61,7 @@
     <% } %>
     <h1>Redirect</h1>
     <p>This is a simple tool provided by <a href="https://www.codeforamerica.org">Code for America</a> to serve shortlinks. All links are held in the <a href="https://github.com/codeforamerica/redirect">Github repo</a>.</p>
-    <a href="https://github.com/codeforamerica/redirect" class="button">Create a shortlink</a>
+    <a href="https://github.com/codeforamerica/redirect/edit/master/redirects.json#L2" class="button">Create a shortlink</a>
   </div>
   <div class="layout-semibreve">
     <h3>List of available redirects</h3>


### PR DESCRIPTION
## Problem:

Users need to be familiar with Github's forking/pull request flow in order to add a redirect to the list.  This is a barrier for entry for non-technical users.
## Solution:

Take advantage of Github's excellent URL schema to point users at the exact page where they can add redirects.

The new URL is:
https://github.com/codeforamerica/redirect/edit/master/redirects.json#L2

If this is the user's first time editing the file, they will be prompted to fork the repository in order to make changes to the file.

After that, it will redirect the user to the "edit" page for the file.  They can edit the JSON in their browser, and click "Propose file change" and "Create pull request" to submit it for review.
