### PR TITLE
encodeURI() on URLs before trying to send a 302 redirect

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ var startApp = function(cb) {
       });
     } else {
       // Send them to the right place
-      res.redirect(302, redirects[req.params.wanted]);
+      res.redirect(302, encodeURI(redirects[req.params.wanted]));
     }
   });
 


### PR DESCRIPTION
Weird characters are tripping up our server, causing it to throw 500's when it tries to send a redirect. I'm encoding the URI to make sure it's safe to parse ... hopefully that works.
