### PR TITLE
Changing Redirect of c4a.me/ctc-response-aid

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -3,7 +3,7 @@
   "folder": "https://drive.google.com/drive/u/1/folders/1SNfni5hogcKRz0W5zEQFqW84pq2WFQFP",
   "internal": "https://airtable.com/shrMFz8NxNFS2PGP6",
   "external": "https://airtable.com/shrEo0NjuZz7vuvec",
-  "ctc-response-aid": "https://calendly.com/mmitchell-gyr/ctc-response-aid",
+  "ctc-response-aid": "https://airtable.com/shrKaLFpXYdExWjSL",
   "networkmob": "https://airtable.com/shrj8Ecudo2yS6ASF",
   "wenowdis": "https://docs.google.com/document/d/1BEjli4aoTzm5I5Iv2Q-mr-cWHz074T6uas9Mk2Mxduo",
   "weknowthis": "https://docs.google.com/document/d/1BEjli4aoTzm5I5Iv2Q-mr-cWHz074T6uas9Mk2Mxduo",


### PR DESCRIPTION
Changing redirect of c4a.me/ctc-response-aid from Calendly page to sign up Airtable form https://airtable.com/shrKaLFpXYdExWjSL