### PR TITLE
Removing Redirect from Calendly to replacement's

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -1729,7 +1729,7 @@
   "expungementmap": "http://s3-us-west-1.amazonaws.com/codeforamerica-cms1/documents/CodeForAmerica-ExpungementJourneyMap.pdf",
   "consent-form": "http://s3-us-west-1.amazonaws.com/codeforamerica-cms1/documents/CodeForAmericaSimpleConsentForm.pdf",
   "consent-form-template": "http://s3-us-west-1.amazonaws.com/codeforamerica-cms1/documents/ConsentFormTemplate.docx",
-  "vita-session": "https://calendly.com/mmitchell-gyr/gyr-info-session",
+  "vita-session": "https://calendly.com/jbarnes-cfa-vols/volunteer-1on1",
   "gyrnttsignup": "https://airtable.com/shrPLfslL3OG2gJ7N",
   "getctcnavigators": "https://www.notion.so/cfa/GetCTC-org-Navigator-Resources-47bd79cc43034fa181e4f54d2131a4b2",
   "memphisyouth": "https://forms.gle/eW6JvvxQBpWjzxbg8",


### PR DESCRIPTION
Changed vita-session redirect my Calendly sign up to Jonathan Barnes, as today is my last day working for GYR/CFA