### PR TITLE
Add links for direct file outreach from GCF 

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -1480,5 +1480,9 @@
   "scsurvey": "https://codeforamerica.co1.qualtrics.com/jfe/form/SV_9pNaB6KNjprT8h0",
   "shelbyoyreport": "https://drive.google.com/file/d/1r0hQxnlvTgI9sIPR_3n-mnAg2ZDSUpA6/view",
   "li-cityofabq": "https://cfa.notion.site/ABQ-End-of-engagement-package-12364e2879ff4ca6b8057f18fbb01f62",
-  "li-homewise": "https://cfa.notion.site/Homewise-End-of-engagement-package-bab0f0bf0bd441c2886c70ec336b0d38"
+  "li-homewise": "https://cfa.notion.site/Homewise-End-of-engagement-package-bab0f0bf0bd441c2886c70ec336b0d38",
+  "child-credit-email": "https://directfile.irs.gov?utm_source=National-Nonprofit&utm_medium=email&utm_campaign=Cfa84&utm_id=directfile",
+  "child-credit-sms": "https://directfile.irs.gov?utm_source=National-Nonprofit&utm_medium=sms&utm_campaign=Cfa84&utm_id=directfile",
+  "direct-file-email": "https://directfile.irs.gov?utm_source=National-Nonprofit&utm_medium=email&utm_campaign=Cfa94&utm_id=directfile",
+  "direct-file-sms": "https://directfile.irs.gov?utm_source=National-Nonprofit&utm_medium=sms&utm_campaign=Cfa94&utm_id=directfile"
 }

--- a/views/index.html
+++ b/views/index.html
@@ -58,7 +58,7 @@
     <% } %>
     <h1>Redirect</h1>
     <p>This is a simple tool provided by <a href="https://www.codeforamerica.org">Code for America</a> to serve shortlinks. All links are held in the <a href="https://github.com/codeforamerica/redirect">Github repo</a>.</p>
-    <a href="https://github.com/codeforamerica/redirect/edit/master/redirects.json#L2" class="button">Create a shortlink</a>
+    <a href="https://github.com/codeforamerica/redirect/edit/main/redirects.json#L2" class="button">Create a shortlink</a>
   </div>
   <div class="layout-semibreve">
     <h3>List of available redirects</h3>


### PR DESCRIPTION
Also fix the broken link on the https://c4a.me/ page 